### PR TITLE
更新 Lamp 依赖版本到 v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ink.magma</groupId>
     <artifactId>FastMinecart</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <name>FastMinecart</name>
@@ -84,14 +84,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.Revxrsal.Lamp</groupId>
-            <artifactId>common</artifactId>
-            <version>3.1.9</version>
+            <groupId>io.github.revxrsal</groupId>
+            <artifactId>lamp.common</artifactId>
+            <version>4.0.0-rc.6</version>
         </dependency>
         <dependency>
-            <groupId>com.github.Revxrsal.Lamp</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>3.1.9</version>
+            <groupId>io.github.revxrsal</groupId>
+            <artifactId>lamp.bukkit</artifactId>
+            <version>4.0.0-rc.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/ink/magma/fastminecart/FastMinecart.java
+++ b/src/main/java/ink/magma/fastminecart/FastMinecart.java
@@ -3,7 +3,7 @@ package ink.magma.fastminecart;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
-import revxrsal.commands.bukkit.BukkitCommandHandler;
+import revxrsal.commands.bukkit.BukkitLamp;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,10 +27,9 @@ public final class FastMinecart extends JavaPlugin implements Listener {
         Bukkit.getPluginManager().registerEvents(new VehicleEventListener(), this);
 
         // commands
-        BukkitCommandHandler handler = BukkitCommandHandler.create(this);
-        handler.enableAdventure();
-        handler.register(new MainCommand());
-        handler.registerBrigadier();
+
+        var lamp = BukkitLamp.builder(this).build();
+        lamp.register(new MainCommand());
 
         getLogger().info("插件已正常载入.");
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,4 @@ name: FastMinecart
 version: '${project.version}'
 main: ink.magma.fastminecart.FastMinecart
 api-version: '1.20'
+authors: [ MagmaBlock, YuanYuanOwO ]


### PR DESCRIPTION
主要是解决`[14:26:04] [Server thread/WARN]: [FastMinecart] "FastMinecart v1.1.1" has registered a listener for com.destroystokyo.paper.event.brigadier.CommandRegisteredEvent on method "public void relocate.FastMinecart.revxrsal.commands.bukkit.brigadier.PaperCommodore$CommandRegisterListener.onCommandRegistered(com.destroystokyo.paper.event.brigadier.CommandRegisteredEvent<?>)", but the event is Deprecated. "This event has been superseded by the Commands API and will be removed in a future release. Listen to LifecycleEvents.COMMANDS instead."; please notify the authors [].`的问题  
经简单测试，可以正常使用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added plugin authors to project metadata

- **Dependencies**
  - Updated Lamp library dependencies to new group and version
    - Upgraded from version 3.1.9 to 4.0.0-rc.6
    - Migrated from `com.github.Revxrsal.Lamp` to `io.github.revxrsal`

- **Project Version**
  - Incremented project version from 1.1.1 to 1.1.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->